### PR TITLE
add: translation language files.

### DIFF
--- a/resources/language/en-us.xml
+++ b/resources/language/en-us.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+
+<Safe value="en-us">
+	<Phrases >
+		<MOUNT>Mount</MOUNT>
+		<UMOUNT>Unmount</UMOUNT>
+		<OPEN>Open</OPEN>
+		<MOUNT_RECENT>Mount Recent</MOUNT_RECENT>
+		<CLEAR_MENU>Clear Menu</CLEAR_MENU>
+		<MOUNT_EXISTING>Mount Existing...</MOUNT_EXISTING>
+		<CREATE_NEW>Create New...</CREATE_NEW>
+		<ABOUT>About </ABOUT>
+		<RUN>Run </RUN>
+		<AT_LOGIN>at Login</AT_LOGIN>
+		<TEST_BUBBLE>Test Bubble</TEST_BUBBLE>
+		<TRIGGER_BREAKPOINT>Trigger Breakpoint</TRIGGER_BREAKPOINT>
+		<THROW_EXCEPTION>Throw Exception</THROW_EXCEPTION>
+		<QUIT>Quit</QUIT>
+		<CREATING_NEW>Creating New</CREATING_NEW>
+		<CREATING_NEW>Creating new</CREATING_NEW>
+
+		<MOUNTING_NEW>Mounting New</MOUNTING_NEW>
+		<MOUNTING_NEW>Mounting new</MOUNTING_NEW>
+
+		<MOUNTING_EXISTING>Mounting Existing</MOUNTING_EXISTING>
+		<MOUNTING_EXISTING>Mounting existing</MOUNTING_EXISTING>
+
+		<VERIFYING>Verifying</VERIFYING>
+		<PASSWORD_UPPERCASE>Password</PASSWORD_UPPERCASE>
+		<PASSWORD_LOWERCASE>password</PASSWORD_LOWERCASE>
+
+		<READING>Reading</READING>
+		<CONFIGURATION>Configuration</CONFIGURATION>
+
+		<PASSWORD_IS_INCORRECT>Password is Incorrect</PASSWORD_IS_INCORRECT>
+		<THE_PASSWORD_YOU_HAVE_ENTERED_IS_INCORRECT>The password you have entered is incorrect.</THE_PASSWORD_YOU_HAVE_ENTERED_IS_INCORRECT>
+
+		<NOT_A>Not a</NOT_A>
+		<THE_LOCATION_YOU_SELECTED_IS_NOT_A>The location you selected is not a</THE_LOCATION_YOU_SELECTED_IS_NOT_A>
+
+		<YOU_CURRENTLY_HAVE_ONE_OR_MORE>You currently have one or more</YOU_CURRENTLY_HAVE_ONE_OR_MORE>
+		<S_MOUNTED_IF_YOU_QUIT_THEY_WILL_NOT_BE_ACCESSIBLE_UNTIL_YOU_RUN>s mounted, if you quit they will not be accessible until you run</S_MOUNTED_IF_YOU_QUIT_THEY_WILL_NOT_BE_ACCESSIBLE_UNTIL_YOU_RUN>
+		<AGAIN>again.</AGAIN>
+		<NOW_QUESTIONMARK>Now?</NOW_QUESTIONMARK>
+
+		<UNKNOWN_ERROR>Unknown Error</UNKNOWN_ERROR>
+		<UNKNOWN_ERROR_OCCURRED_WHILE_CREATING_NEW>Unknown error occurred while creating new</UNKNOWN_ERROR_OCCURRED_WHILE_CREATING_NEW>
+		<UNKNOWN_ERROR_OCCURRED_WHILE_MOUNTING_EXISTING>Unknown error occurred while mounting existing</UNKNOWN_ERROR_OCCURRED_WHILE_MOUNTING_EXISTING>
+
+		<WELCOME_TO>Welcome to</WELCOME_TO>
+
+		<IS_NOW_RUNNING>is now Running!</IS_NOW_RUNNING>
+
+		<SAFE_TRAY_ICON_MAC_WELCOME_MSG_A>If you need to use</SAFE_TRAY_ICON_MAC_WELCOME_MSG_A>
+		<SAFE_TRAY_ICON_MAC_WELCOME_MSG_B>, just click on the</SAFE_TRAY_ICON_MAC_WELCOME_MSG_B>
+		<SAFE_TRAY_ICON_MAC_WELCOME_MSG_C>menu bar icon.</SAFE_TRAY_ICON_MAC_WELCOME_MSG_C>
+
+		<SAFE_DIALOG_WELCOME_TEXT_A>is now running. You can use it by clicking the</SAFE_DIALOG_WELCOME_TEXT_A>
+		<SAFE_DIALOG_WELCOME_TEXT_B>icon in the tray. Get started by clicking one of the actions below:</SAFE_DIALOG_WELCOME_TEXT_B>
+		<SAFE_DIALOG_WELCOME_TEXT_POST_DRIVER_INSTALL_A>Congrats! Your system is now configured to use</SAFE_DIALOG_WELCOME_TEXT_POST_DRIVER_INSTALL_A>
+		<SAFE_DIALOG_WELCOME_TEXT_POST_DRIVER_INSTALL_B>Get started by clicking one of the actions below:</SAFE_DIALOG_WELCOME_TEXT_POST_DRIVER_INSTALL_B>
+
+		<SAFE_NOTIFICATION_TEST_TITLE>Short Title</SAFE_NOTIFICATION_TEST_TITLE>
+		<SAFE_NOTIFICATION_TEST_MESSAGE>Very long message full of meaningful info that you will find very interesting because you love to read tray icon bubbles. Don't you? Don't you?!?!</SAFE_NOTIFICATION_TEST_MESSAGE>
+
+		<SAFE_DIALOG_ABOUT_TAGLINE>Protect your files.</SAFE_DIALOG_ABOUT_TAGLINE>
+		<SAFE_DIALOG_ABOUT_VERSION>Version</SAFE_DIALOG_ABOUT_VERSION>
+
+		<SAFE_DIALOG_ABOUT_BYLINE> is free software.</SAFE_DIALOG_ABOUT_BYLINE>
+
+		<SAFE_TRAY_ICON_SEND_FEEDBACK>Send Feedback...</SAFE_TRAY_ICON_SEND_FEEDBACK>
+
+		<SAFE_DIALOG_REBOOT_CONFIRMATION_TITLE>Reboot Now?</SAFE_DIALOG_REBOOT_CONFIRMATION_TITLE>
+		<SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_A>Your PC must be rebooted before it is secure enough to use</SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_A>
+		<SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_B>. If you cancel you can reboot on your own later.</SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_B>
+
+		<SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_MAC_A>Your computer must be rebooted before it is secure enough to use</SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_MAC_A>
+		<SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_MAC_B>. You can also quit</SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_MAC_B>
+		<SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_MAC_C>and reboot on your own later. Reboot now?</SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_MAC_C>
+
+
+		<SAFE_DIALOG_SYSTEM_CHANGES_TITLE>System Changes Required</SAFE_DIALOG_SYSTEM_CHANGES_TITLE>
+		<SAFE_DIALOG_SYSTEM_CHANGES_HEADER>Before using Safe, we recommend making the following changes to your system:</SAFE_DIALOG_SYSTEM_CHANGES_HEADER>
+		<SAFE_DIALOG_SYSTEM_CHANGES_FOOTER>These changes are critical for ensuring your privacy when using Safe but may not be necessary for your use case. If in doubt, we strongly recommend making these changes.</SAFE_DIALOG_SYSTEM_CHANGES_FOOTER>
+		<SAFE_DIALOG_SYSTEM_CHANGES_MAKE_CHANGES>Make Changes</SAFE_DIALOG_SYSTEM_CHANGES_MAKE_CHANGES>
+		<SAFE_DIALOG_SYSTEM_CHANGES_DONT_MAKE_CHANGES>Don't Make Changes</SAFE_DIALOG_SYSTEM_CHANGES_DONT_MAKE_CHANGES>
+		<SAFE_DIALOG_SYSTEM_CHANGES_MORE_INFO>More Info</Phrases>
+
+		<SAFE_PROGRESS_SYSTEM_CHANGES_TITLE>Making System Changes</SAFE_PROGRESS_SYSTEM_CHANGES_TITLE>
+		<SAFE_PROGRESS_SYSTEM_CHANGES_MESSAGE>Making System Changes...</SAFE_PROGRESS_SYSTEM_CHANGES_MESSAGE>
+
+		<VISIT_WEBSITE>Visit Website</VISIT_WEBSITE>
+		<GET_SOURCE_CODE>Get Source Code</GET_SOURCE_CODE>
+
+		<LOCATION>Location</LOCATION>
+		<BROWSE>Browse</BROWSE>
+		<NAME>Name</NAME>
+		<CONFIRM>Confirm</CONFIRM>
+		<OK>OK</OK>
+		<CANCEL>Cancel</CANCEL>
+		<SHOW_PASSWORD>Show Password</SHOW_PASSWORD>
+
+		<WE_ARE_UNABLE_TO_MOUNT_MORE_THAN_A_SINGLE_SAFE_WINDOWS_XP_A>We are unable to mount more than a single Safe at a time on Windows XP. Would you like to unmount</WE_ARE_UNABLE_TO_MOUNT_MORE_THAN_A_SINGLE_SAFE_WINDOWS_XP_A>
+		<WE_ARE_UNABLE_TO_MOUNT_MORE_THAN_A_SINGLE_SAFE_WINDOWS_XP_B>first?</WE_ARE_UNABLE_TO_MOUNT_MORE_THAN_A_SINGLE_SAFE_WINDOWS_XP_B>
+		<CANNOT_CREATE_NEW_SAFE>Cannot Create New Safe</CANNOT_CREATE_NEW_SAFE>
+		<CANNOT_MOUNT_EXISTING_SAFE>Cannot Mount Existing Safe</CANNOT_MOUNT_EXISTING_SAFE>
+
+		<INSTALL_WEBDAV_RAMDISK_CACHE>Install WebDAV RAMDisk cache</INSTALL_WEBDAV_RAMDISK_CACHE>
+		<DISABLE_HIBERNATE_SLEEP>Disable hibernate sleep</DISABLE_HIBERNATE_SLEEP>
+		<ENABLE_PAGEFILE_ENCRYPTION>Enable pagefile encryption</ENABLE_PAGEFILE_ENCRYPTION>
+
+		<WINDOWS_XP_WARNING>Windows XP Warning</WINDOWS_XP_WARNING>
+	    <RUN_WINXP_WARNING_DIALOG_A>The security of</RUN_WINXP_WARNING_DIALOG_A>
+	    <RUN_WINXP_WARNING_DIALOG_B>is degraded while running under Windows XP. This is not a strictly a limitation of</RUN_WINXP_WARNING_DIALOG_B>
+	    <RUN_WINXP_WARNING_DIALOG_C>and most security products on Windows XP suffer from the same weakness.\n\nIf you expect that the only people who will ever have access to your internal hard disk are trusted, then this is not an issue. Otherwise we don't recommend running</RUN_WINXP_WARNING_DIALOG_C>
+	    <RUN_WINXP_WARNING_DIALOG_D>in this environment unless you know exactly what you're doing.</RUN_WINXP_WARNING_DIALOG_D>
+
+		<CONTINUE>Continue</CONTINUE>
+		<MORE_INFO>More Info</MORE_INFO>
+		<QUIT>Quit</QUIT>
+
+	</Phrases>
+</Safe> 

--- a/src/safe/constants.h
+++ b/src/safe/constants.h
@@ -21,6 +21,7 @@
 
 #include <safe/product_name.h>
 #include <safe/version.h>
+#include "language.hpp"
 
 #define SAFE_APP_STARTED_COOKIE_FILENAME "AppStarted"
 #define SAFE_RECENTLY_USED_PATHS_DB_FILE_NAME "RecentPaths.db"
@@ -44,96 +45,86 @@ enum {
 
 #define SAFE_TRAY_ICON_TOOLTIP PRODUCT_NAME_A
 
-#define SAFE_PROGRESS_CREATING_TITLE ("Creating New " ENCRYPTED_STORAGE_NAME_A "...")
-#define SAFE_PROGRESS_CREATING_MESSAGE ("Creating new " ENCRYPTED_STORAGE_NAME_A "...")
+#define SAFE_PROGRESS_CREATING_TITLE (get_phrase("CREATING_NEW") " " ENCRYPTED_STORAGE_NAME_A "...")
+#define SAFE_PROGRESS_CREATING_MESSAGE (get_phrase("CREATING_NEW") " " ENCRYPTED_STORAGE_NAME_A "...")
 
-#define SAFE_PROGRESS_MOUNTING_TITLE ("Mounting New " ENCRYPTED_STORAGE_NAME_A "...")
-#define SAFE_PROGRESS_MOUNTING_MESSAGE ("Mounting new " ENCRYPTED_STORAGE_NAME_A "...")
+#define SAFE_PROGRESS_MOUNTING_TITLE (get_phrase("MOUNTING_NEW") " " ENCRYPTED_STORAGE_NAME_A "...")
+#define SAFE_PROGRESS_MOUNTING_MESSAGE (get_phrase("MOUNTING_NEW") " " ENCRYPTED_STORAGE_NAME_A "...")
 
-#define SAFE_PROGRESS_MOUNTING_EXISTING_TITLE ("Mounting Existing " ENCRYPTED_STORAGE_NAME_A "...")
-#define SAFE_PROGRESS_MOUNTING_EXISTING_MESSAGE ("Mounting existing " ENCRYPTED_STORAGE_NAME_A "...")
+#define SAFE_PROGRESS_MOUNTING_EXISTING_TITLE (get_phrase("MOUNTING_EXISTING") " " ENCRYPTED_STORAGE_NAME_A "...")
+#define SAFE_PROGRESS_MOUNTING_EXISTING_MESSAGE (get_phrase("MOUNTING_EXISTING") " " ENCRYPTED_STORAGE_NAME_A "...")
 
-#define SAFE_PROGRESS_VERIFYING_PASS_TITLE ("Verifying " ENCRYPTED_STORAGE_NAME_A " Password...")
-#define SAFE_PROGRESS_VERIFYING_PASS_MESSAGE ("Verifying " ENCRYPTED_STORAGE_NAME_A " password...")
+#define SAFE_PROGRESS_VERIFYING_PASS_TITLE (get_phrase("VERIFYING") " " ENCRYPTED_STORAGE_NAME_A " " get_phrase("PASSWORD_UPPERCASE"))
+#define SAFE_PROGRESS_VERIFYING_PASS_MESSAGE (get_phrase("VERIFYING") " " ENCRYPTED_STORAGE_NAME_A " " get_phrase("PASSWORD_LOWERCASE"))
 
-#define SAFE_PROGRESS_READING_CONFIG_TITLE ("Reading " ENCRYPTED_STORAGE_NAME_A " Configuration...")
-#define SAFE_PROGRESS_READING_CONFIG_MESSAGE ("Reading " ENCRYPTED_STORAGE_NAME_A " configuration...")
+#define SAFE_PROGRESS_READING_CONFIG_TITLE (get_phrase("READING") " " ENCRYPTED_STORAGE_NAME_A " " get_phrase("CONFIGURATION"))
+#define SAFE_PROGRESS_READING_CONFIG_MESSAGE (get_phrase("READING") " " ENCRYPTED_STORAGE_NAME_A " " get_phrase("CONFIGURATION"))
 
-#define SAFE_DIALOG_PASS_INCORRECT_TITLE "Password is Incorrect"
-#define SAFE_DIALOG_PASS_INCORRECT_MESSAGE "The password you have entered is incorrect."
+#define SAFE_DIALOG_PASS_INCORRECT_TITLE get_phrase("PASSWORD_IS_INCORRECT")
+#define SAFE_DIALOG_PASS_INCORRECT_MESSAGE get_phrase("THE_PASSWORD_YOU_HAVE_ENTERED_IS_INCORRECT")
 
-#define SAFE_DIALOG_NO_CONFIG_EXISTS_TITLE ("Not a " ENCRYPTED_STORAGE_NAME_A)
-#define SAFE_DIALOG_NO_CONFIG_EXISTS_MESSAGE ("The location you selected is not a " ENCRYPTED_STORAGE_NAME_A ".")
+#define SAFE_DIALOG_NO_CONFIG_EXISTS_TITLE (get_phrase("NOT_A")" " ENCRYPTED_STORAGE_NAME_A)
+#define SAFE_DIALOG_NO_CONFIG_EXISTS_MESSAGE (get_phrase("THE_LOCATION_YOU_SELECTED_IS_NOT_A")" " ENCRYPTED_STORAGE_NAME_A ".")
 
-#define SAFE_DIALOG_QUIT_CONFIRMATION_TITLE ("Quit " PRODUCT_NAME_A " Now?")
-#define SAFE_DIALOG_QUIT_CONFIRMATION_MESSAGE ("You currently have one or more " ENCRYPTED_STORAGE_NAME_A "s mounted, if you quit they will not be accessible until you run " PRODUCT_NAME_A " again. Quit " PRODUCT_NAME_A " Now?")
+#define SAFE_DIALOG_QUIT_CONFIRMATION_TITLE (get_phrase("QUIT") PRODUCT_NAME_A " " get_phrase("NOW_QUESTIONMARK"))
+#define SAFE_DIALOG_QUIT_CONFIRMATION_MESSAGE (get_phrase("YOU_CURRENTLY_HAVE_ONE_OR_MORE") " " ENCRYPTED_STORAGE_NAME_A get_phrase("S_MOUNTED",_IF_YOU_QUIT_THEY_WILL_NOT_BE_ACCESSIBLE_UNTIL_YOU_RUN) " " PRODUCT_NAME_A " " get_phrase("AGAIN") " " get_phrase("QUIT") PRODUCT_NAME_A " " get_phrase("NOW_QUESTIONMARK"))
 
-#define SAFE_DIALOG_UNKNOWN_CREATE_ERROR_TITLE "Unknown Error"
-#define SAFE_DIALOG_UNKNOWN_CREATE_ERROR_MESSAGE ("Unknown error occurred while creating new " ENCRYPTED_STORAGE_NAME_A ".")
+#define SAFE_DIALOG_UNKNOWN_CREATE_ERROR_TITLE get_phrase("UNKNOWN_ERROR")
+#define SAFE_DIALOG_UNKNOWN_CREATE_ERROR_MESSAGE (get_phrase("UNKNOWN_ERROR_OCCURRED_WHILE_CREATING_NEW") " " ENCRYPTED_STORAGE_NAME_A ".")
 
-#define SAFE_DIALOG_UNKNOWN_MOUNT_ERROR_TITLE "Unknown Error"
-#define SAFE_DIALOG_UNKNOWN_MOUNT_ERROR_MESSAGE ("Unknown error occurred while mounting existing " ENCRYPTED_STORAGE_NAME_A ".")
+#define SAFE_DIALOG_UNKNOWN_MOUNT_ERROR_TITLE get_phrase("UNKNOWN_ERROR")
+#define SAFE_DIALOG_UNKNOWN_MOUNT_ERROR_MESSAGE (get_phrase("UNKNOWN_ERROR_OCCURRED_WHILE_MOUNTING_EXISTING")" " ENCRYPTED_STORAGE_NAME_A ".")
 
-#define SAFE_DIALOG_ABOUT_TITLE ("About " PRODUCT_NAME_A)
-#define SAFE_DIALOG_WELCOME_TITLE ("Welcome to " PRODUCT_NAME_A "!")
+#define SAFE_DIALOG_ABOUT_TITLE (get_phrase("ABOUT") " " PRODUCT_NAME_A)
+#define SAFE_DIALOG_WELCOME_TITLE (get_phrase("WELCOME_TO") " " PRODUCT_NAME_A "!")
 
-#define SAFE_TRAY_ICON_WELCOME_TITLE (PRODUCT_NAME_A " is now Running!")
-#define SAFE_TRAY_ICON_WELCOME_MSG                                   \
-  (                                                                     \
-   "If you need to use "                                                \
-   PRODUCT_NAME_A                                                       \
-   ", just right-click on this icon."                                   \
-                                                      )
-#define SAFE_TRAY_ICON_MAC_WELCOME_MSG ("If you need to use " PRODUCT_NAME_A ", just click on the " PRODUCT_NAME_A " menu bar icon.")
+#define SAFE_TRAY_ICON_WELCOME_TITLE (PRODUCT_NAME_A " " get_phrase("IS_NOW_RUNNING"))
+
+#define SAFE_TRAY_ICON_MAC_WELCOME_MSG \
+  (get_phrase("SAFE_TRAY_ICON_MAC_WELCOME_MSG_A") \
+    PRODUCT_NAME_A get_phrase("SAFE_TRAY_ICON_MAC_WELCOME_MSG_B") \
+    PRODUCT_NAME_A get_phrase("SAFE_TRAY_ICON_MAC_WELCOME_MSG_C"))
 
 #define SAFE_DIALOG_WELCOME_TEXT \
-  (PRODUCT_NAME_A " is now running. You can use it by clicking "        \
-   "the " PRODUCT_NAME_A " icon in the tray. Get started by clicking "  \
-   "one of the actions below:")
+  (PRODUCT_NAME_A " " get_phrase("SAFE_DIALOG_WELCOME_TEXT_A")
+    PRODUCT_NAME_A " "get_phrase("SAFE_DIALOG_WELCOME_TEXT_B"))
+
 #define SAFE_DIALOG_WELCOME_TEXT_POST_DRIVER_INSTALL \
-  ("Congrats! Your system is now configured to use " PRODUCT_NAME_A ". " \
-   "Get started by clicking one of the actions below:")
+  (get_phrase("SAFE_DIALOG_WELCOME_TEXT_POST_DRIVER_INSTALL_A") PRODUCT_NAME_A ". " \
+   get_phrase("SAFE_DIALOG_WELCOME_TEXT_POST_DRIVER_INSTALL_B"))
 
 #define SAFE_DIALOG_WELCOME_CREATE_BUTTON \
-  ("Create New " ENCRYPTED_STORAGE_NAME_A "...")
+  (get_phrase("CREATE_NEW") ENCRYPTED_STORAGE_NAME_A "...")
 #define SAFE_DIALOG_WELCOME_MOUNT_BUTTON \
-  ("Mount Existing " ENCRYPTED_STORAGE_NAME_A "...")
+  (get_phrase("MOUNT_EXISTING") ENCRYPTED_STORAGE_NAME_A "...")
 
-#define SAFE_NOTIFICATION_TEST_TITLE "Short Title"
-#define SAFE_NOTIFICATION_TEST_MESSAGE \
-  ("Very long message full of meaningful info that you " \
-   "will find very interesting because you love to read " \
-   "tray icon bubbles. Don't you? Don't you?!?!")
+#define SAFE_NOTIFICATION_TEST_TITLE get_phrase("SAFE_NOTIFICATION_TEST_TITLE")
+#define SAFE_NOTIFICATION_TEST_MESSAGE get_phrase("SAFE_NOTIFICATION_TEST_MESSAGE")
 
-#define SAFE_DIALOG_ABOUT_TAGLINE "Protect your files."
-#define SAFE_DIALOG_ABOUT_VERSION "Version " SAFE_VERSION_STR
+#define SAFE_DIALOG_ABOUT_TAGLINE get_phrase("SAFE_DIALOG_ABOUT_TAGLINE")
+#define SAFE_DIALOG_ABOUT_VERSION get_phrase("SAFE_DIALOG_ABOUT_VERSION") " " SAFE_VERSION_STR
 
-#define SAFE_DIALOG_ABOUT_BYLINE (PRODUCT_NAME_A " is free software.")
+#define SAFE_DIALOG_ABOUT_BYLINE (PRODUCT_NAME_A " " get_phrase("SAFE_DIALOG_ABOUT_BYLINE"))
 
-#define SAFE_TRAY_ICON_SEND_FEEDBACK "Send Feedback..."
+#define SAFE_TRAY_ICON_SEND_FEEDBACK get_phrase("SAFE_TRAY_ICON_SEND_FEEDBACK")
 
-#define SAFE_DIALOG_REBOOT_CONFIRMATION_TITLE ("Reboot Now?")
-#define SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE \
-  ("Your PC must be rebooted before it is secure enough to use " \
-   PRODUCT_NAME_A ". If you cancel you can reboot on your own later.")
-#define SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_MAC \
-  ("Your computer must be rebooted before it is secure enough to use " \
-   PRODUCT_NAME_A ". You can also quit " PRODUCT_NAME_A " and reboot on " \
-   "your own later. Reboot now?")
+#define SAFE_DIALOG_REBOOT_CONFIRMATION_TITLE get_phrase("SAFE_DIALOG_REBOOT_CONFIRMATION_TITLE")
+#define SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE  (get_phrase("SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_A")   PRODUCT_NAME_A get_phrase("SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_B"))
+#define SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_MAC  \
+  (get_phrase("SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_MAC_A")" " \
+  PRODUCT_NAME_A get_phrase("SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_MAC_B") PRODUCT_NAME_A\
+  " " get_phrase("SAFE_DIALOG_REBOOT_CONFIRMATION_MESSAGE_MAC_C"))
 
-#define SAFE_DIALOG_SYSTEM_CHANGES_TITLE "System Changes Required"
-#define SAFE_DIALOG_SYSTEM_CHANGES_HEADER \
-  "Before using Safe, we recommend making the following changes to your system:"
+
+#define SAFE_DIALOG_SYSTEM_CHANGES_TITLE get_phrase("SAFE_DIALOG_SYSTEM_CHANGES_TITLE") 
+#define SAFE_DIALOG_SYSTEM_CHANGES_HEADER get_phrase("SAFE_DIALOG_SYSTEM_CHANGES_HEADER")  
 #define SAFE_DIALOG_SYSTEM_CHANGES_BULLET "•"
-#define SAFE_DIALOG_SYSTEM_CHANGES_FOOTER \
-  "These changes are critical for ensuring your privacy when using Safe but "\
-  "may not be necessary for your use case. If in doubt, we strongly recommend "\
-  "making these changes."
-#define SAFE_DIALOG_SYSTEM_CHANGES_MAKE_CHANGES "Make Changes"
-#define SAFE_DIALOG_SYSTEM_CHANGES_DONT_MAKE_CHANGES "Don't Make Changes"
-#define SAFE_DIALOG_SYSTEM_CHANGES_MORE_INFO "More Info"
+#define SAFE_DIALOG_SYSTEM_CHANGES_FOOTER get_phrase("SAFE_DIALOG_SYSTEM_CHANGES_FOOTER")  
+#define SAFE_DIALOG_SYSTEM_CHANGES_MAKE_CHANGES get_phrase("SAFE_DIALOG_SYSTEM_CHANGES_MAKE_CHANGES") 
+#define SAFE_DIALOG_SYSTEM_CHANGES_DONT_MAKE_CHANGES get_phrase("SAFE_DIALOG_SYSTEM_CHANGES_DONT_MAKE_CHANGES") 
+#define SAFE_DIALOG_SYSTEM_CHANGES_MORE_INFO get_phrase("SAFE_DIALOG_SYSTEM_CHANGES_MORE_INFO") 
 
-#define SAFE_PROGRESS_SYSTEM_CHANGES_TITLE "Making System Changes"
-#define SAFE_PROGRESS_SYSTEM_CHANGES_MESSAGE "Making System Changes..."
+#define SAFE_PROGRESS_SYSTEM_CHANGES_TITLE get_phrase("SAFE_PROGRESS_SYSTEM_CHANGES_TITLE") 
+#define SAFE_PROGRESS_SYSTEM_CHANGES_MESSAGE get_phrase("SAFE_PROGRESS_SYSTEM_CHANGES_MESSAGE") 
 
 #endif

--- a/src/safe/language.cpp
+++ b/src/safe/language.cpp
@@ -1,0 +1,100 @@
+/*
+  Safe: Encrypted File System
+  Copyright (C) 2013 Rian Hunter <rian@alum.mit.edu>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include "language.hpp"
+#include <iostream>
+
+/////////////////////////
+// Specific exceptions //
+/////////////////////////
+
+// struct InvalidLanguage: public std::runtime_error{
+//   InvalidLanguage()
+//   {
+
+//   }
+//   InvalidLanguage(std::string const& message)
+//       : std::runtime_error(message + " Was thrown")
+//   {}
+// } InvalidLanguage;
+
+// struct UnknownPhrase: public std::runtime_error{
+//   UnknownPhrase()
+//   {
+    
+//   }
+//   UnknownPhrase(std::string const& message)
+//       : std::runtime_error(message + " Was thrown")
+//   {}
+// } UnknownPhrase;
+
+/////////////////////////
+/////////////////////////
+
+
+PhraseMap phrase_map;
+
+/**
+ * Defines the default language used by get_phrase()
+ * @int l - supported_language value
+ */
+void set_language(int l){
+  // Verifies if "l" is a valid language pack
+  // if(l < 0 || l >= LEN_SUPPORTED_LANGUAGES)
+    // throw InvalidLanguage((char)l);
+
+  // Load the input file
+  TiXmlDocument lang;
+  lang.LoadFile(language_files[l]);  
+  // assert(lang);
+
+  TiXmlHandle hDoc(&lang);
+  TiXmlElement* pElem;
+
+  phrase_map.clear(); // trash existing table
+
+  // Iterate through elements inside "Phrases" and stores each one in the map object
+  pElem = hDoc.FirstChild( "Safe" ).FirstChild("Phrases").FirstChild().Element();
+  for( pElem; pElem; pElem=pElem->NextSiblingElement())
+  {
+    const char *pKey=pElem->Value();
+    const char *pText=pElem->GetText();
+    if (pKey && pText) 
+    {
+      phrase_map[pKey] = pText;
+      std::cout << pKey << " = " << pText << std::endl;
+    }
+  }
+}
+
+/**
+ * Returns a arbitrarily string 
+ * @param  token - A token relative to the desired phrase
+ * @return      - A phrase relative to "code" and to the language set
+ */
+std::string get_phrase(std::string token){
+  PhraseIterator it = phrase_map.find(token);
+  if(it != phrase_map.end()){
+    // Found it
+    return it->second;
+  }else{
+    // Didn't found it
+    // throw UnknownPhrase(token);
+    throw std::invalid_argument(token + " phrase not found.");
+  }
+}

--- a/src/safe/language.hpp
+++ b/src/safe/language.hpp
@@ -1,0 +1,41 @@
+/*
+  Safe: Encrypted File System
+  Copyright (C) 2013 Rian Hunter <rian@alum.mit.edu>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+#ifndef LANGUAGE__HPP
+#define LANGUAGE__HPP
+#include <stdexcept>
+#include <string>
+#include <map>
+#include "tinyxml.h"
+
+///////////////////////////////////////////////////////////////////
+// Defines the supported languages and the respective input file //
+///////////////////////////////////////////////////////////////////
+enum supported_languages {EN_US,LEN_SUPPORTED_LANGUAGES};
+const char * const language_files[] = {"../resources/language/en-us.xml"};
+typedef std::map<std::string,std::string> PhraseMap;
+typedef std::map<std::string,std::string>::iterator PhraseIterator;
+///////////////////////////////////////////////////////////////////
+
+///////////////
+// Functions //
+///////////////
+void set_language(int l);
+
+std::string get_phrase(std::string token);
+
+#endif

--- a/src/safe/tray_menu.hpp
+++ b/src/safe/tray_menu.hpp
@@ -25,6 +25,8 @@
 #include <cassert>
 #include <cstdint>
 
+#include "language.hpp"
+
 namespace safe {
 
 enum class TrayMenuAction : uint16_t {
@@ -104,11 +106,11 @@ populate_tray_menu(Menu & menu,
   std::string mount_verb_string;
   TrayMenuAction mount_action_id;
   if (show_unmount) {
-    mount_verb_string = "Unmount";
+    mount_verb_string = get_phrase("UNMOUNT");
     mount_action_id = TrayMenuAction::UNMOUNT;
   }
   else {
-    mount_verb_string = "Open";
+    mount_verb_string =get_phrase( "OPEN");
     mount_action_id = TrayMenuAction::OPEN;
   }
 
@@ -124,7 +126,7 @@ populate_tray_menu(Menu & menu,
 
   // create "Mount Recent" submenu
   if (true) {
-    auto sub_menu = menu.append_menu("Mount Recent");
+    auto sub_menu = menu.append_menu(get_phrase("MOUNT_RECENT"));
 
     tray_menu_action_arg_t sub_tag = 0;
     for (const auto & p : recent_mounts) {
@@ -147,24 +149,24 @@ populate_tray_menu(Menu & menu,
 
     if (sub_tag) sub_menu.append_separator();
 
-    auto item = sub_menu.append_item("Clear Menu", TrayMenuAction::CLEAR_RECENTS);
+    auto item = sub_menu.append_item(get_phrase("CLEAR_MENU"), TrayMenuAction::CLEAR_RECENTS);
     if (!sub_tag) item.disable();
   }
 
   // Mount an Existing Bitvault
-  menu.append_item("Mount Existing...", TrayMenuAction::MOUNT);
+  menu.append_item(get_phrase("MOUNT_EXISTING"), TrayMenuAction::MOUNT);
 
   // Create a New Bitvault
-  menu.append_item("Create New...", TrayMenuAction::CREATE);
+  menu.append_item(get_phrase("CREATE_NEW"), TrayMenuAction::CREATE);
 
   menu.append_separator();
 
   // About Bitvault
-  menu.append_item("About " PRODUCT_NAME_A, TrayMenuAction::ABOUT_APP);
+  menu.append_item(get_phrase("ABOUT") PRODUCT_NAME_A, TrayMenuAction::ABOUT_APP);
 
   menu.append_item(SAFE_TRAY_ICON_SEND_FEEDBACK, TrayMenuAction::SEND_FEEDBACK);
 
-  menu.append_item("Run " PRODUCT_NAME_A " at Login",
+  menu.append_item(get_phrase("RUN") " " PRODUCT_NAME_A " " get_phrase("AT_LOGIN"),
                      TrayMenuAction::TOGGLE_RUN_AT_LOGIN)
     .set_checked(startup_enabled);
 
@@ -172,16 +174,16 @@ populate_tray_menu(Menu & menu,
   menu.append_separator();
 
   // Test Bubble
-  menu.append_item("Test Bubble", TrayMenuAction::TEST_BUBBLE);
+  menu.append_item(get_phrase("TEST_BUBBLE"), TrayMenuAction::TEST_BUBBLE);
 
-  menu.append_item("Trigger Breakpoint", TrayMenuAction::TRIGGER_BREAKPOINT);
+  menu.append_item(get_phrase("TRIGGER_BREAKPOINT"), TrayMenuAction::TRIGGER_BREAKPOINT);
 
-  menu.append_item("Throw Exception", TrayMenuAction::THROW_EXCEPTION);
+  menu.append_item(get_phrase("THROW_EXCEPTION"), TrayMenuAction::THROW_EXCEPTION);
 #endif
 
   menu.append_separator();
 
-  menu.append_item("Quit " PRODUCT_NAME_A, TrayMenuAction::QUIT_APP);
+  menu.append_item(get_phrase("QUIT") " " PRODUCT_NAME_A, TrayMenuAction::QUIT_APP);
 }
 
 }

--- a/src/safe/win/about_dialog.cpp
+++ b/src/safe/win/about_dialog.cpp
@@ -21,6 +21,7 @@
 #include <safe/constants.h>
 #include <safe/win/dialog_common.hpp>
 #include <safe/logging.h>
+#include <safe/language.hpp>
 #include <safe/win/resources.h>
 #include <w32util/dialog.hpp>
 #include <w32util/gui_util.hpp>
@@ -29,6 +30,7 @@
 #include <cassert>
 
 #include <windows.h>
+
 
 namespace safe { namespace win {
 
@@ -183,13 +185,13 @@ about_dialog(HWND hwnd) {
   const unit_t VERSION_LEFT = 0;
   const unit_t VERSION_TOP = TAGLINE_TOP + TAGLINE_HEIGHT + 8;
 
-  const auto VISIT_TEXT = "Visit Website";
+  const auto VISIT_TEXT = get_phrase("VISIT_WEBSITE");
   const unit_t VISIT_WIDTH = button_width(VISIT_TEXT);
   const unit_t VISIT_HEIGHT = 12;
   const unit_t VISIT_LEFT = center_offset(DIALOG_WIDTH, VISIT_WIDTH);
   const unit_t VISIT_TOP = VERSION_TOP + VERSION_HEIGHT + 8;
 
-  const auto SOURCE_TEXT = "Get Source Code...";
+  const auto SOURCE_TEXT = get_phrase("GET_SOURCE_CODE");
   const unit_t SOURCE_WIDTH = button_width(SOURCE_TEXT);
   const unit_t SOURCE_HEIGHT = 12;
   const unit_t SOURCE_LEFT = center_offset(DIALOG_WIDTH, SOURCE_WIDTH);
@@ -204,7 +206,7 @@ about_dialog(HWND hwnd) {
 
   const auto dlg =
     DialogTemplate(DialogDesc(DEFAULT_MODAL_DIALOG_STYLE | WS_VISIBLE,
-                              "About Safe", 0, 0, DIALOG_WIDTH, DIALOG_HEIGHT,
+                              get_phrase("ABOUT") " Safe", 0, 0, DIALOG_WIDTH, DIALOG_HEIGHT,
                               FontDescription(desired_point, narrow(message_font.lfFaceName))),
                    {
                      CText(PRODUCT_NAME_A, IDC_LOGO_TEXT,

--- a/src/safe/win/app_main.cpp
+++ b/src/safe/win/app_main.cpp
@@ -316,16 +316,14 @@ handle_multiple_mounts(HWND safe_main_window,
   auto mount_name = wd.mounts.front().get_mount_name();
 
   std::string message = 
-    ("We are unable to mount more than a single "
-     "Safe at a time on Windows XP. Would you like to unmount \"") +
-    mount_name +
-    ("\" first?");
+    (get_phrase("WE_ARE_UNABLE_TO_MOUNT_MORE_THAN_A_SINGLE_SAFE_WINDOWS_XP_A") " \"") +
+    mount_name + ("\" " get_phrase("FIRST"));
 
   auto ret = w32util::check_call(0, MessageBoxW, safe_main_window,
                                  w32util::widen(message).c_str(),
                                  (creating
-                                  ? L"Cannot Create New Safe"
-                                  : L"Cannot Mount Existing Safe"),
+                                  ? L get_phrase("CANNOT_CREATE_NEW_SAFE")
+                                  : L get_phrase("CANNOT_MOUNT_EXISTING_SAFE"),
                                  MB_YESNO | MB_ICONEXCLAMATION | MB_SETFOREGROUND);
   if (ret != IDYES) return false;
 
@@ -912,15 +910,15 @@ required_system_changes() {
   std::vector<std::string> to_ret;
 
   if (safe::win::need_to_install_kernel_driver()) {
-    to_ret.push_back("Install WebDAV RAMDisk cache");
+    to_ret.push_back(get_phrase("INSTALL WEBDAV RAMDISK CACHE)"));
   }
 
   if (hibernate_is_enabled()) {
-    to_ret.push_back("Disable hibernate sleep");
+    to_ret.push_back(get_phrase("DISABLE HIBERNATE SLEEP"));
   }
 
   if (!encrypted_pagefile_is_enabled()) {
-    to_ret.push_back("Enable pagefile encryption");
+    to_ret.push_back(get_phrase("ENABLE PAGEFILE ENCRYPTION"));
   }
 
   return to_ret;
@@ -1098,17 +1096,8 @@ static
 std::pair<bool, bool>
 run_winxp_warning_dialog(HWND hwnd) {
   std::string message =
-    ("The security of " PRODUCT_NAME_A " is degraded while "
-     "running under Windows XP. This is not a strictly a limitation of "
-     PRODUCT_NAME_A " and most security products on Windows XP "
-     "suffer from the same weakness."
-     "\n\n"
-     "If you expect that the only "
-     "people who will ever have access to your internal hard "
-     "disk are trusted, "
-     "then this is not an issue. Otherwise we don't recommend "
-     "running " PRODUCT_NAME_A " in this environment unless you "
-     "know exactly what you're doing."
+    (get_phrase("RUN_WINXP_WARNING_DIALOG_A") " " PRODUCT_NAME_A " " get_phrase("RUN_WINXP_WARNING_DIALOG_B")
+     " " PRODUCT_NAME_A " " get_phrase("RUN_WINXP_WARNING_DIALOG_C") " " PRODUCT_NAME_A " " get_phrase("RUN_WINXP_WARNING_DIALOG_A")
      );
 
   enum class XPWarningChoice {
@@ -1123,9 +1112,9 @@ run_winxp_warning_dialog(HWND hwnd) {
   };
 
   std::vector<safe::win::Choice<XPWarningChoice>> choices = {
-    {"Continue", XPWarningChoice::CONTINUE},
-    {"More Info", more_info},
-    {"Quit", XPWarningChoice::QUIT},
+    {get_phrase("CONTINUE"), XPWarningChoice::CONTINUE},
+    {get_phrase("MORE_INFO"), more_info},
+    {get_phrase("QUIT"), XPWarningChoice::QUIT},
   };
 
   auto ret =

--- a/src/safe/win/create_safe_dialog.cpp
+++ b/src/safe/win/create_safe_dialog.cpp
@@ -19,6 +19,7 @@
 #include <safe/win/create_safe_dialog.hpp>
 
 #include <safe/constants.h>
+#include <safe/language.hpp>
 #include <safe/create_safe_dialog_logic.hpp>
 #include <safe/win/dialog_common.hpp>
 #include <safe/win/report_bug_dialog.hpp>
@@ -270,14 +271,14 @@ create_new_safe_dialog(HWND owner, std::shared_ptr<encfs::FsIO> fsio) {
 
   const auto dlg =
     DialogTemplate(DialogDesc(DEFAULT_MODAL_DIALOG_STYLE | WS_VISIBLE,
-                              "Create New " ENCRYPTED_STORAGE_NAME_A,
+                              get_phrase("CREATE_NEW") " " ENCRYPTED_STORAGE_NAME_A,
                               0, 0, DIALOG_WIDTH, DIALOG_HEIGHT),
                    {
-                     LText(("Create New " ENCRYPTED_STORAGE_NAME_A),
+                     LText((get_phrase("CREATE_NEW") " " ENCRYPTED_STORAGE_NAME_A),
                            IDC_STATIC,
                            HEADING_LEFT, HEADING_TOP,
                            HEADING_WIDTH, HEADING_HEIGHT),
-                     LText("Location:", IDC_STATIC,
+                     LText(get_phrase("LOCATION") ":", IDC_STATIC,
                            LOCATION_LABEL_LEFT, LOCATION_LABEL_TOP,
                            LOCATION_LABEL_WIDTH, LOCATION_LABEL_HEIGHT),
                      EditText(IDC_LOCATION,
@@ -285,10 +286,10 @@ create_new_safe_dialog(HWND owner, std::shared_ptr<encfs::FsIO> fsio) {
                               LOCATION_ENTRY_WIDTH, LOCATION_ENTRY_HEIGHT,
                               ES_READONLY | ES_LEFT | ES_AUTOHSCROLL |
                               WS_BORDER),
-                     PushButton("Browse", IDC_BROWSE,
+                     PushButton(get_phrase("BROWSE"), IDC_BROWSE,
                                 BROWSE_BTN_LEFT, BROWSE_BTN_TOP,
                                 BROWSE_BTN_WIDTH, BROWSE_BTN_HEIGHT),
-                     LText(ENCRYPTED_STORAGE_NAME_A " Name:", IDC_STATIC,
+                     LText(ENCRYPTED_STORAGE_NAME_A " "get_phrase("NAME")":", IDC_STATIC,
                            NAME_LABEL_LEFT, NAME_LABEL_TOP,
                            NAME_LABEL_WIDTH, NAME_LABEL_HEIGHT),
                      EditText(IDC_NAME,
@@ -296,7 +297,7 @@ create_new_safe_dialog(HWND owner, std::shared_ptr<encfs::FsIO> fsio) {
                               NAME_ENTRY_WIDTH, NAME_ENTRY_HEIGHT,
                               ES_LEFT | WS_BORDER | WS_TABSTOP |
                               ES_AUTOHSCROLL),
-                     LText("Password:", IDC_STATIC,
+                     LText(get_phrase("PASSWORD_UPPERCASE")":", IDC_STATIC,
                            PASS_LABEL_LEFT, PASS_LABEL_TOP,
                            PASS_LABEL_WIDTH, PASS_LABEL_HEIGHT),
                      EditText(IDC_PASSWORD,
@@ -304,7 +305,7 @@ create_new_safe_dialog(HWND owner, std::shared_ptr<encfs::FsIO> fsio) {
                               PASS_ENTRY_WIDTH, PASS_ENTRY_HEIGHT,
                               ES_PASSWORD | ES_LEFT | ES_AUTOHSCROLL |
                               WS_BORDER | WS_TABSTOP),
-                     LText("Confirm:", IDC_STATIC,
+                     LText(get_phrase("CONFIRM")":", IDC_STATIC,
                            CONFIRM_LABEL_LEFT, CONFIRM_LABEL_TOP,
                            CONFIRM_LABEL_WIDTH, CONFIRM_LABEL_HEIGHT),
                      EditText(IDC_CONFIRM_PASSWORD,
@@ -312,10 +313,10 @@ create_new_safe_dialog(HWND owner, std::shared_ptr<encfs::FsIO> fsio) {
                               CONFIRM_ENTRY_WIDTH, CONFIRM_ENTRY_HEIGHT,
                               ES_PASSWORD | ES_LEFT | ES_AUTOHSCROLL |
                               WS_BORDER | WS_TABSTOP),
-                     DefPushButton("OK", IDOK,
+                     DefPushButton(get_phrase("OK"), IDOK,
                                    OK_BTN_LEFT, OK_BTN_TOP,
                                    OK_BTN_WIDTH, OK_BTN_HEIGHT),
-                     PushButton("Cancel", IDCANCEL,
+                     PushButton(get_phrase("CANCEL"), IDCANCEL,
                                 CANCEL_BTN_LEFT, CANCEL_BTN_TOP,
                                 CANCEL_BTN_WIDTH, CANCEL_BTN_HEIGHT),
                    }

--- a/src/safe/win/mount_safe_dialog.cpp
+++ b/src/safe/win/mount_safe_dialog.cpp
@@ -19,6 +19,7 @@
 #include <safe/win/mount_safe_dialog.hpp>
 
 #include <safe/constants.h>
+#include <safe/language.hpp>
 #include <safe/win/dialog_common.hpp>
 #include <safe/mount_safe_dialog_logic.hpp>
 #include <safe/win/mount.hpp>
@@ -312,14 +313,14 @@ mount_existing_safe_dialog(HWND hwnd, std::shared_ptr<encfs::FsIO> fsio,
 
   auto dlg =
     DialogTemplate(DialogDesc(DEFAULT_MODAL_DIALOG_STYLE | WS_VISIBLE,
-                              "Mount Existing " ENCRYPTED_STORAGE_NAME_A,
+                              get_phrase("MOUNT_EXISTING") " " ENCRYPTED_STORAGE_NAME_A,
                               0, 0, DIALOG_WIDTH, DIALOG_HEIGHT),
                    {
-                     LText(("Mount Existing " ENCRYPTED_STORAGE_NAME_A),
+                     LText((get_phrase("MOUNT_EXISTING") " " ENCRYPTED_STORAGE_NAME_A),
                            IDC_STATIC,
                            HEADING_LEFT, HEADING_TOP,
                            HEADING_WIDTH, HEADING_HEIGHT),
-                     LText("Location:", IDC_STATIC,
+                     LText(get_phrase("LOCATION") ":", IDC_STATIC,
                            LOCATION_LABEL_LEFT, LOCATION_LABEL_TOP,
                            LOCATION_LABEL_WIDTH, LOCATION_LABEL_HEIGHT),
                      EditText(IDC_LOCATION,
@@ -327,10 +328,10 @@ mount_existing_safe_dialog(HWND hwnd, std::shared_ptr<encfs::FsIO> fsio,
                               LOCATION_ENTRY_WIDTH, LOCATION_ENTRY_HEIGHT,
                               ES_READONLY | ES_LEFT | ES_AUTOHSCROLL |
                               WS_BORDER),
-                     PushButton("Browse", IDC_BROWSE,
+                     PushButton(get_phrase("BROWSE"), IDC_BROWSE,
                                 BROWSE_BTN_LEFT, BROWSE_BTN_TOP,
                                 BROWSE_BTN_WIDTH, BROWSE_BTN_HEIGHT),
-                     LText("Password:", IDC_STATIC,
+                     LText(get_phrase("PASSWORD_UPPERCASE")":", IDC_STATIC,
                            PASS_LABEL_LEFT, PASS_LABEL_TOP,
                            PASS_LABEL_WIDTH, PASS_LABEL_HEIGHT),
                      EditText(IDC_PASSWORD,
@@ -338,14 +339,14 @@ mount_existing_safe_dialog(HWND hwnd, std::shared_ptr<encfs::FsIO> fsio,
                               PASS_ENTRY_WIDTH, PASS_ENTRY_HEIGHT,
                               ES_PASSWORD | ES_LEFT | ES_AUTOHSCROLL |
                               WS_BORDER | WS_TABSTOP),
-                     CheckBox("Show Password", IDC_SHOW_PASSWORD,
+                     CheckBox(get_phrase("SHOW_PASSWORD"), IDC_SHOW_PASSWORD,
                               SHOW_PASSWORD_LEFT, SHOW_PASSWORD_TOP,
                               SHOW_PASSWORD_WIDTH, SHOW_PASSWORD_HEIGHT,
 			      BS_AUTOCHECKBOX | WS_TABSTOP),
-                     DefPushButton("OK", IDOK,
+                     DefPushButton(get_phrase("OK"), IDOK,
                                    OK_BTN_LEFT, OK_BTN_TOP,
                                    OK_BTN_WIDTH, OK_BTN_HEIGHT),
-                     PushButton("Cancel", IDCANCEL,
+                     PushButton(get_phrase("CANCEL"), IDCANCEL,
                                 CANCEL_BTN_LEFT, CANCEL_BTN_TOP,
                                 CANCEL_BTN_WIDTH, CANCEL_BTN_HEIGHT),
                    }


### PR DESCRIPTION
- added safe/language.cpp. It handles all queries for app-strings.
- added resources/language/en-us.xml as the en-us language pack.
- all hard-coded phrases were moved to the en-us language pack.

This PR is related to the issue 81.